### PR TITLE
Fix memory leak by clearing activity reference

### DIFF
--- a/src/main/java/com/buglife/sdk/ForegroundDetector.java
+++ b/src/main/java/com/buglife/sdk/ForegroundDetector.java
@@ -23,7 +23,6 @@ import android.os.Bundle;
 
 class ForegroundDetector implements Application.ActivityLifecycleCallbacks {
     private Activity mCurrentActivity = null;
-    private boolean mForegrounded = false;
     private final OnForegroundListener mOnForegroundListener;
 
     interface OnForegroundListener {
@@ -41,7 +40,7 @@ class ForegroundDetector implements Application.ActivityLifecycleCallbacks {
     }
 
     boolean getForegrounded() {
-        return mForegrounded;
+        return mCurrentActivity != null;
     }
 
     @Override
@@ -57,13 +56,12 @@ class ForegroundDetector implements Application.ActivityLifecycleCallbacks {
     @Override
     public void onActivityResumed(Activity activity) {
         mCurrentActivity = activity;
-        mForegrounded = true;
         mOnForegroundListener.onForegroundEvent();
     }
 
     @Override
     public void onActivityPaused(Activity activity) {
-        mForegrounded = false;
+        mCurrentActivity = null;
         mOnForegroundListener.onBackgroundEvent();
     }
 


### PR DESCRIPTION
Library shouldn't hold a reference of a paused activity. Such behavior causes a memory leaks as old activity can't be collected by a Garbage Collector

Original: https://github.com/Buglife/buglife-android/pull/75